### PR TITLE
Comparing secure in cookie ignoring case

### DIFF
--- a/src/main/java/HTTPClient/Cookie.java
+++ b/src/main/java/HTTPClient/Cookie.java
@@ -196,7 +196,7 @@ public class Cookie implements Serializable {
 
             end = set_cookie.indexOf('=', beg);
             if (end == -1) {
-                if (set_cookie.substring(beg).trim().equals("secure")) {
+                if (set_cookie.substring(beg).trim().equalsIgnoreCase("secure")) {
                     end = set_cookie.length();
                     curr.secure = true;
                 } else {


### PR DESCRIPTION
Hi,
I was testing our web app with nGrinder and run into following error, 


2017-07-06 09:28:28,068 ERROR Bad Set-Cookie header: X-Uaa-Csrf=d98G5x1EXzPBqysjDBCaGZ; Expires=Sat, 05-Aug-2017 07:28:28 GMT;, JSESSIONID=0C2290F8A3405537A197727B20E9E457; Path=/; Secure;, __VCAP_ID__=8d770aab-6a59-4195-6454-9190; Path=/;, Secure
No '=' found for token starting at position 188
java.net.ProtocolException: Bad Set-Cookie header: X-Uaa-Csrf=d98G5x1EXzPBqysjDBCaGZ; Expires=Sat, 05-Aug-2017 07:28:28 GMT;, JSESSIONID=0C2290F8A3405537A197727B20E9E457; Path=/; Secure;, __VCAP_ID__=8d770aab-6a59-4195-6454-9190; Path=/;, Secure
No '=' found for token starting at position 188
	at HTTPClient.Cookie.parse(Cookie.java:203) ~[grinder-patch-3.9.1-patch.jar:na]
	at HTTPClient.CookieModule.handleCookie(CookieModule.java:472) ~[grinder-httpclient-3.9.1.jar:na]
	at HTTPClient.CookieModule.responsePhase1Handler(CookieModule.java:421) ~[grinder-httpclient-3.9.1.jar:na]
	at HTTPClient.HTTPResponse.handleResponse(HTTPResponse.java:745) ~[grinder-httpclient-3.9.1.jar:na]
	at HTTPClient.HTTPResponse.getData(HTTPResponse.java:510) ~[grinder-httpclient-3.9.1.jar:na]
	at net.grinder.plugin.http.HTTPRequest$AbstractRequest.getHTTPResponse(HTTPRequest.java:1290) ~[grinder-http-3.9.1.jar:na]
	at net.grinder.plugin.http.HTTPRequest.GET(HTTPRequest.java:499) ~[grinder-http-3.9.1.jar:na]
	at net.grinder.plugin.http.HTTPRequest.GET(HTTPRequest.java:445) ~[grinder-http-3.9.1.jar:na]
	at net.grinder.plugin.http.HTTPRequest$GET.call(Unknown Source) ~[na:na]
	at Login.test(script.groovy:96) ~[na:na]
	at net.grinder.scriptengine.groovy.junit.GrinderRunner.run(GrinderRunner.java:170) ~[ngrinder-groovy-3.4.1.jar:na]
	at net.grinder.scriptengine.groovy.GroovyScriptEngine$GroovyWorkerRunnable.run(GroovyScriptEngine.java:147) ~[ngrinder-groovy-3.4.1.jar:na]
	at net.grinder.engine.process.GrinderThread.run(GrinderThread.java:118) ~[grinder-core-3.9.1.jar:na]


It seems that when inspecting "secure" keyword in the cookie header, it missed "Secure" case.  Could you review and hopefully merge the change?